### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/parent/cq5-dependencies/pom.xml
+++ b/parent/cq5-dependencies/pom.xml
@@ -1545,22 +1545,22 @@
             <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
-                <version>3.2.1</version>
+                <version>3.2.2</version>
                 <scope>provided</scope>
                 <!--
                     Export-Package:
-                    - org.apache.commons.collections.map;version="3.2.1"
-                    - org.apache.commons.collections.buffer;version="3.2.1"
-                    - org.apache.commons.collections.comparators;version="3.2.1"
-                    - org.apache.commons.collections.collection;version="3.2.1"
-                    - org.apache.commons.collections.bag;version="3.2.1"
-                    - org.apache.commons.collections.iterators;version="3.2.1"
-                    - org.apache.commons.collections.bidimap;version="3.2.1"
-                    - org.apache.commons.collections.set;version="3.2.1"
-                    - org.apache.commons.collections.functors;version="3.2.1"
-                    - org.apache.commons.collections.list;version="3.2.1"
-                    - org.apache.commons.collections.keyvalue;version="3.2.1"
-                    - org.apache.commons.collections;version="3.2.1"
+                    - org.apache.commons.collections.map;version="3.2.2"
+                    - org.apache.commons.collections.buffer;version="3.2.2"
+                    - org.apache.commons.collections.comparators;version="3.2.2"
+                    - org.apache.commons.collections.collection;version="3.2.2"
+                    - org.apache.commons.collections.bag;version="3.2.2"
+                    - org.apache.commons.collections.iterators;version="3.2.2"
+                    - org.apache.commons.collections.bidimap;version="3.2.2"
+                    - org.apache.commons.collections.set;version="3.2.2"
+                    - org.apache.commons.collections.functors;version="3.2.2"
+                    - org.apache.commons.collections.list;version="3.2.2"
+                    - org.apache.commons.collections.keyvalue;version="3.2.2"
+                    - org.apache.commons.collections;version="3.2.2"
                 -->
             </dependency>
             <dependency>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
